### PR TITLE
Use apksigner to sign and extract keys from apks instead of keytool

### DIFF
--- a/ruby-gem/lib/calabash-android/dependencies.rb
+++ b/ruby-gem/lib/calabash-android/dependencies.rb
@@ -68,6 +68,10 @@ module Calabash
                 android_dependencies(:zipalign_path)
             end
 
+            def self.apksigner_path
+                android_dependencies(:apksigner_path)
+            end
+
             def self.android_jar_path
                 android_dependencies(:android_jar_path)
             end
@@ -229,6 +233,12 @@ module Calabash
                 aapt_path = scan_for_path(android_sdk_location, aapt_executable, tools_directories(android_sdk_location))
                 zipalign_path = scan_for_path(android_sdk_location, zipalign_executable, tools_directories(android_sdk_location))
 
+                if ENV['APKSIGNER_PATH']
+                    apksigner_path = ENV['APKSIGNER_PATH']
+                else
+                    apksigner_path = scan_for_path(android_sdk_location, apksigner_executable, tools_directories(android_sdk_location))
+                end
+
                 if adb_path.nil?
                     raise Environment::InvalidEnvironmentError,
                           "Could not find '#{adb_executable}' in '#{android_sdk_location}'"
@@ -244,8 +254,14 @@ module Calabash
                           "Could not find '#{zipalign_executable}' in '#{android_sdk_location}'"
                 end
 
+                if apksigner_path.nil?
+                    raise Environment::InvalidEnvironmentError,
+                          "Could not find '#{apksigner_executable}' in '#{android_sdk_location}'"
+                end
+
                 Logging.log_debug("Set aapt path to '#{aapt_path}'")
                 Logging.log_debug("Set zipalign path to '#{zipalign_path}'")
+                Logging.log_debug("Set apksigner path to '#{apksigner_path}'")
                 Logging.log_debug("Set adb path to '#{adb_path}'")
 
                 android_jar_path = scan_for_path(File.join(android_sdk_location, 'platforms'), 'android.jar', [File.basename(platform_directory(android_sdk_location))])
@@ -260,6 +276,7 @@ module Calabash
                 {
                     aapt_path: aapt_path,
                     zipalign_path: zipalign_path,
+                    apksigner_path: apksigner_path,
                     adb_path: adb_path,
                     android_jar_path: android_jar_path
                 }
@@ -484,6 +501,10 @@ module Calabash
 
             def self.zipalign_executable
                 is_windows? ? 'zipalign.exe' : 'zipalign'
+            end
+
+            def self.apksigner_executable
+                is_windows? ? 'apksigner.exe' : 'apksigner'
             end
 
             def self.jarsigner_executable

--- a/ruby-gem/lib/calabash-android/helpers.rb
+++ b/ruby-gem/lib/calabash-android/helpers.rb
@@ -92,7 +92,11 @@ def checksum(file_path)
 end
 
 def test_server_path(apk_file_path)
-  "test_servers/#{checksum(apk_file_path)}_#{Calabash::Android::VERSION}.apk"
+  if ENV['TEST_APP_PATH']
+    ENV['TEST_APP_PATH']
+  else
+    "test_servers/#{checksum(apk_file_path)}_#{Calabash::Android::VERSION}.apk"
+  end
 end
 
 def build_test_server_if_needed(app_path)

--- a/ruby-gem/lib/calabash-android/java_keystore.rb
+++ b/ruby-gem/lib/calabash-android/java_keystore.rb
@@ -80,6 +80,8 @@ class JavaKeystore
     unless result
       raise "Could not sign app: #{apk_path}"
     end
+
+    FileUtils.cp(apk_path, dest_path)
   end
 
   def system_with_stdout_on_success(cmd, *args)

--- a/ruby-gem/lib/calabash-android/java_keystore.rb
+++ b/ruby-gem/lib/calabash-android/java_keystore.rb
@@ -62,23 +62,20 @@ class JavaKeystore
     log "Signing using the digest algorithm: '#{digest_algorithm}'"
 
     cmd_args = {
-      '-sigfile' => 'CERT',
-      '-sigalg' => signing_algorithm,
-      '-digestalg' => digest_algorithm,
-      '-signedjar' => dest_path,
-      '-storepass' => password,
-      '-keystore' =>  location,
+      '--ks-key-alias' => keystore_alias,
+      '--ks-pass' => "pass:#{password}",
+      '--ks' =>  location,
     }
 
     unless @key_password.nil?
-      cmd_args['-keypass'] = @key_password
+      cmd_args['--key-pass'] = "pass:#{@key_password}"
     end
 
     cmd_args = cmd_args.flatten
+    cmd_args.unshift('sign')
     cmd_args << apk_path
-    cmd_args << keystore_alias
 
-    result = system_with_stdout_on_success(Calabash::Android::Dependencies.jarsigner_path, *cmd_args)
+    result = system_with_stdout_on_success(Calabash::Android::Dependencies.apksigner_path, *cmd_args)
 
     unless result
       raise "Could not sign app: #{apk_path}"

--- a/ruby-gem/lib/calabash-android/java_keystore.rb
+++ b/ruby-gem/lib/calabash-android/java_keystore.rb
@@ -62,6 +62,7 @@ class JavaKeystore
     log "Signing using the digest algorithm: '#{digest_algorithm}'"
 
     cmd_args = {
+      '--out' => dest_path,
       '--ks-key-alias' => keystore_alias,
       '--ks-pass' => "pass:#{password}",
       '--ks' =>  location,
@@ -80,8 +81,6 @@ class JavaKeystore
     unless result
       raise "Could not sign app: #{apk_path}"
     end
-
-    FileUtils.cp(apk_path, dest_path)
   end
 
   def system_with_stdout_on_success(cmd, *args)

--- a/ruby-gem/lib/calabash-android/version.rb
+++ b/ruby-gem/lib/calabash-android/version.rb
@@ -1,7 +1,7 @@
 module Calabash
   module Android
 
-    VERSION = "0.9.12.uia10"
+    VERSION = "0.9.12.uia11"
     # Server Commit 6b8a1ad9b645df91a297d4c85ff202e6f0cdda27     patch AccessibilityNodeInfoDumper to include all the non-visible elements and dump everything
 
 


### PR DESCRIPTION
Use `apksigner` from Android SDK instead of Java keytool to support v2, v3 and v4 APK signatures
Add the ability to override it with the `APKSIGNER_PATH` environment variable